### PR TITLE
matching a migration filename have appropriate datetime format

### DIFF
--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -137,13 +137,15 @@ final class FileRepository implements RepositoryInterface
                 throw new RepositoryException("Invalid migration filename '{$filename}'");
             }
 
+            $created = \DateTime::createFromFormat(self::TIMESTAMP_FORMAT, $definition[0]);
+            if (false === $created) {
+                throw new RepositoryException("Invalid migration filename '{$filename}' - corrupted date format");
+            }
+
             yield [
                 'filename' => $filename,
                 'class'    => $reflection->getClasses()[0],
-                'created'  => \DateTime::createFromFormat(
-                    self::TIMESTAMP_FORMAT,
-                    $definition[0]
-                ),
+                'created'  => $created,
                 'chunk'    => $definition[1],
                 'name'     => str_replace(
                     '.php',

--- a/tests/Migrations/ExceptionsTest.php
+++ b/tests/Migrations/ExceptionsTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Migrations\Tests;
 
+use DateTime;
 use Spiral\Migrations\Fixtures\AddForeignKeyMigration;
 use Spiral\Migrations\Fixtures\AlterForeignKeyMigration;
 use Spiral\Migrations\Fixtures\AlterNonExistedColumnMigration;
@@ -353,12 +354,22 @@ abstract class ExceptionsTest extends BaseTest
         $this->migrator->run();
     }
 
-    /**
-     * @expectedException \Spiral\Migrations\Exception\RepositoryException
-     */
     public function testBadMigrationFile(): void
     {
         file_put_contents(__DIR__ . '/../files/mmm.php', 'test');
+
+        $this->expectException(\Spiral\Migrations\Exception\RepositoryException::class);
+        $this->expectExceptionMessageMatches("/Invalid migration filename '.+'/");
+        $this->repository->getMigrations();
+    }
+
+    public function testBadDateFormatMigrationFile(): void
+    {
+        $fileName = (new \DateTime())->format('dmY-his') . '_0_test.php';
+        file_put_contents(__DIR__ . "/../files/{$fileName}", 'test');
+
+        $this->expectException(\Spiral\Migrations\Exception\RepositoryException::class);
+        $this->expectExceptionMessageMatches("/Invalid migration filename '.+' - corrupted date format/");
         $this->repository->getMigrations();
     }
 


### PR DESCRIPTION
When \DateTime::createFromFormat returns false, when file name not match time format.
This cause that FileRepository::getFiles yields `created` as `false`.
Future in FileRepository::getMigrations in array calls `$f['created']->getTimestamp()` from false, not \DateTime.