### PR TITLE
[feature]: issue13 - add created_at field

### DIFF
--- a/src/FileRepository.php
+++ b/src/FileRepository.php
@@ -95,6 +95,7 @@ final class FileRepository implements RepositoryInterface
             );
         }
 
+        $currentTimeStamp = date(self::TIMESTAMP_FORMAT);
         $inflectedName = $this->inflector->tableize($name);
 
         foreach ($this->getMigrations() as $migration) {
@@ -104,7 +105,10 @@ final class FileRepository implements RepositoryInterface
                 );
             }
 
-            if ($migration->getState()->getName() === $inflectedName) {
+            if (
+                $migration->getState()->getName() === $inflectedName
+                && $migration->getState()->getTimeCreated()->format(self::TIMESTAMP_FORMAT) === $currentTimeStamp
+            ) {
                 throw new RepositoryException(
                     "Unable to register migration '{$inflectedName}', migration under the same name already exists"
                 );

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Spiral\Migrations;
 
+use Spiral\Database\Database;
 use Spiral\Database\DatabaseManager;
 use Spiral\Database\Table;
 use Spiral\Migrations\Config\MigrationConfig;
@@ -19,6 +20,13 @@ use Spiral\Migrations\Exception\MigrationException;
 final class Migrator
 {
     private const DB_DATE_FORMAT = 'Y-m-d H:i:s';
+
+    private const MIGRATION_TABLE_FIELDS_LIST = [
+        'id',
+        'migration',
+        'time_executed',
+        'created_at'
+    ];
 
     /** @var MigrationConfig */
     private $config;
@@ -68,12 +76,12 @@ final class Migrator
     public function isConfigured(): bool
     {
         foreach ($this->dbal->getDatabases() as $db) {
-            if (!$db->hasTable($this->config->getTable())) {
+            if (!$db->hasTable($this->config->getTable()) || !$this->checkMigrationTableStructure($db)) {
                 return false;
             }
         }
 
-        return true;
+        return !$this->isRestoreMigrationDataRequired();
     }
 
     /**
@@ -92,9 +100,19 @@ final class Migrator
             $schema->primary('id');
             $schema->string('migration', 255)->nullable(false);
             $schema->datetime('time_executed')->datetime();
-            $schema->index(['migration']);
+            $schema->datetime('created_at')->datetime();
+            $schema->index(['migration', 'created_at'])
+                ->unique(true);
+
+            if ($schema->hasIndex(['migration'])) {
+                $schema->dropIndex(['migration']);
+            }
 
             $schema->save();
+        }
+
+        if ($this->isRestoreMigrationDataRequired()) {
+            $this->restoreMigrationData();
         }
     }
 
@@ -145,7 +163,8 @@ final class Migrator
                 $this->migrationTable($migration->getDatabase())->insertOne(
                     [
                         'migration' => $migration->getState()->getName(),
-                        'time_executed' => new \DateTime('now')
+                        'time_executed' => new \DateTime('now'),
+                        'created_at' => $this->getMigrationCreatedAtForDb($migration),
                     ]
                 );
 
@@ -197,11 +216,13 @@ final class Migrator
                 }
             );
 
-            $this->migrationTable($migration->getDatabase())->delete(
-                [
-                    'migration' => $migration->getState()->getName()
-                ]
-            )->run();
+            $migrationData = $this->fetchMigrationData($migration);
+
+            if (!empty($migrationData)) {
+                $this->migrationTable($migration->getDatabase())
+                    ->delete(['id' => $migrationData['id']])
+                    ->run();
+            }
 
             return $migration->withState($this->resolveState($migration));
         }
@@ -219,11 +240,7 @@ final class Migrator
     {
         $db = $this->dbal->database($migration->getDatabase());
 
-        //Fetch migration information from database
-        $data = $this->migrationTable($migration->getDatabase())
-            ->select('id', 'time_executed')
-            ->where(['migration' => $migration->getState()->getName()])
-            ->run()->fetch();
+        $data = $this->fetchMigrationData($migration);
 
         if (empty($data['time_executed'])) {
             return $migration->getState()->withStatus(State::STATUS_PENDING);
@@ -244,5 +261,103 @@ final class Migrator
     protected function migrationTable(string $database = null): Table
     {
         return $this->dbal->database($database)->table($this->config->getTable());
+    }
+
+    protected function checkMigrationTableStructure(Database $db): bool
+    {
+        $table = $db->table($this->config->getTable());
+
+        foreach (self::MIGRATION_TABLE_FIELDS_LIST as $field) {
+            if (!$table->hasColumn($field)) {
+                return false;
+            }
+        }
+
+        if (!$table->hasIndex(['migration', 'created_at'])) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Fetch migration information from database
+     *
+     * @param MigrationInterface $migration
+     *
+     * @return array|null
+     */
+    protected function fetchMigrationData(MigrationInterface $migration): ?array
+    {
+        $migrationData = $this->migrationTable($migration->getDatabase())
+            ->select('id', 'time_executed', 'created_at')
+            ->where(
+                [
+                    'migration' => $migration->getState()->getName(),
+                    'created_at' => $this->getMigrationCreatedAtForDb($migration)->format(self::DB_DATE_FORMAT),
+                ]
+            )
+            ->run()
+            ->fetch();
+
+        return is_array($migrationData) ? $migrationData : [];
+    }
+
+    protected function restoreMigrationData(): void
+    {
+        foreach ($this->repository->getMigrations() as $migration) {
+            $migrationData = $this->migrationTable($migration->getDatabase())
+                ->select('id')
+                ->where(
+                    [
+                        'migration' => $migration->getState()->getName(),
+                        'created_at' => null,
+                    ]
+                )
+                ->run()
+                ->fetch();
+
+            if (!empty($migrationData)) {
+                $this->migrationTable($migration->getDatabase())
+                    ->update(
+                        ['created_at' => $this->getMigrationCreatedAtForDb($migration)],
+                        ['id' => $migrationData['id']]
+                    )
+                    ->run();
+            }
+        }
+    }
+
+    /**
+     * Check if some data modification required
+     *
+     * @return bool
+     */
+    protected function isRestoreMigrationDataRequired(): bool
+    {
+        foreach ($this->dbal->getDatabases() as $db) {
+            $table = $db->table($this->config->getTable());
+
+            if (
+                $table->select('id')
+                    ->where(['created_at' => null])
+                    ->count() > 0
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function getMigrationCreatedAtForDb(MigrationInterface $migration): \DateTimeInterface
+    {
+        $db = $this->dbal->database($migration->getDatabase());
+
+        return \DateTimeImmutable::createFromFormat(
+            self::DB_DATE_FORMAT,
+            $migration->getState()->getTimeCreated()->format(self::DB_DATE_FORMAT),
+            $db->getDriver()->getTimezone()
+        );
     }
 }

--- a/tests/Migrations/MigratorTest.php
+++ b/tests/Migrations/MigratorTest.php
@@ -17,6 +17,14 @@ use Spiral\Migrations\Exception\MigrationException;
 
 abstract class MigratorTest extends BaseTest
 {
+    public function testIsConfigured(): void
+    {
+        $this->assertFalse($this->migrator->isConfigured());
+
+        $this->migrator->configure();
+        $this->assertTrue($this->migrator->isConfigured());
+    }
+
     public function testConfigure(): void
     {
         $this->assertFalse($this->migrator->isConfigured());
@@ -34,6 +42,20 @@ abstract class MigratorTest extends BaseTest
         $this->assertTrue($this->db->hasTable('migrations'));
 
         $this->migrator->configure();
+    }
+
+    public function testConfiguredTableStructure(): void
+    {
+        $this->migrator->configure();
+        $table = $this->db->table('migrations');
+
+        $this->assertTrue($table->hasColumn('id'));
+        $this->assertTrue($table->hasColumn('migration'));
+        $this->assertTrue($table->hasColumn('time_executed'));
+        $this->assertTrue($table->hasColumn('created_at'));
+
+        $this->assertFalse($table->hasIndex(['migration']));
+        $this->assertTrue($table->hasIndex(['migration', 'created_at']));
     }
 
     public function testGetEmptyMigrations(): void


### PR DESCRIPTION
Checked by scenario on local project:

1.  Create basic migrations on master branch
2. Create migration with similar name as one of existing
3. Try to run command `cycle:migrate`
	- RepositoryException occured `Unable to register migration '0_core_change_users_alter_email', migration under the same name already exists`
4. Update Migrator.php to updated version
5. Try to run command `migrate`
	- Message that command `migrate:init` required
6. Run command `migrate:init`
7. Check table structure:
	- new field created_at (datetime)
	- new unique index by columns (migration, created_at)
8. Created old migrations - created_at column should contain datetime in db locale similar to date from filename
9. Try to run command `migrate` 
    - No outstanding migrations were found.
10. Try to run command `cycle:migrate` to create migration from step 3
	- Ok
11. Try to run command `migrate` 
	- Ok
12. Try to rollback last migration
	- Only last migration was deleted